### PR TITLE
Some interrupt stuff, Transfer::recycle() prototype

### DIFF
--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -322,6 +322,12 @@ impl<Id: ChId> Channel<Id, Busy> {
         // flag raised
         CallbackStatus::TransferError
     }
+
+    /// Restart transfer using previously-configured trigger source and action
+    #[inline]
+    pub(crate) fn restart(&mut self) {
+        self.regs.chctrla.modify(|_, w| w.enable().set_bit());
+    }
 }
 
 /// Status of a transfer callback

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -168,6 +168,18 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
             .write(|w| unsafe { w.bits(flags.into()) });
     }
 
+    /// Check the specified `flags`, clear then return any that were set
+    #[inline]
+    pub fn check_and_clear_interrupts(&mut self, flags: InterruptFlags) -> InterruptFlags {
+        let mut cleared = 0;
+        self.regs.chintflag.modify(|r, w| {
+            cleared = r.bits() & flags.into_bytes()[0];
+            unsafe { w.bits(cleared) }
+        });
+
+        InterruptFlags::from_bytes([cleared])
+    }
+
     #[inline]
     fn _reset_private(&mut self) {
         // Reset the channel to its startup state and wait for reset to complete
@@ -268,17 +280,9 @@ impl<Id: ChId> Channel<Id, Busy> {
     }
 
     /// Returns whether or not the transfer is complete.
-    ///
-    /// BUSYCH is set when the channel is ACTIVELY transferring;
-    /// PENDCH is set when a trigger request has been received
-    /// but the transfer hasn't been started yet.
-    /// Therefore, when a trigger request is issued, PENDCH will be set first,
-    /// then when the arbiter begins to service the channel, PENDCH is cleared
-    /// and BUSYCH is set. To make sure the transfer is actually complete, the
-    /// channel needs to be both NOT PENDING and NOT BUSY.
     #[inline]
     pub(crate) fn xfer_complete(&self) -> bool {
-        !self.regs.busych.read_bit() && !self.regs.pendch.read_bit()
+        !self.regs.chctrla.read().enable().bit_is_set()
     }
 
     /// Stop transfer on channel whether or not the transfer has completed

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -166,7 +166,11 @@ pub use transfer::{Beat, Buffer, Transfer};
 pub enum DmacError {
     /// Supplied buffers both have lengths > 1 beat, but not equal to each other
     ///
-    /// This is a 
+    /// Buffers need to either have the same length in beats, or one should have
+    /// length == 1.  In cases where one buffer is length 1, that buffer will be
+    /// the source or destination of each beat in the transfer.  If both buffers
+    /// had length >1, but not equal to each other, then it would not be clear
+    /// how to structure the transfer.
     LengthMismatch,
 
     /// Operation is not valid in the current state of the object.

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -162,6 +162,20 @@ pub use dma_controller::{
 use transfer::BeatSize;
 pub use transfer::{Beat, Buffer, Transfer};
 
+#[derive(Debug)]
+pub enum DmacError {
+    /// Supplied buffers both have lengths > 1 beat, but not equal to each other
+    ///
+    /// This is a 
+    LengthMismatch,
+
+    /// Operation is not valid in the current state of the object.
+    InvalidState,
+}
+
+/// Result for DMAC operations
+pub type Result<T> = core::result::Result<T, DmacError>;
+
 #[cfg(all(feature = "samd11", feature = "max-channels"))]
 #[macro_export]
 macro_rules! with_num_channels {

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -149,7 +149,7 @@ impl_beat!(
 pub unsafe trait Buffer {
     type Beat: Beat;
     /// Pointer to the buffer. If the buffer is incrementing, the address should
-    /// point to the last beat transfer in the block.
+    /// point to one past the last beat transfer in the block.
     fn dma_ptr(&mut self) -> *mut Self::Beat;
     /// Return whether the buffer pointer should be incrementing or not
     fn incrementing(&self) -> bool;

--- a/hal/src/sercom/v2.rs
+++ b/hal/src/sercom/v2.rs
@@ -46,8 +46,10 @@ pub trait Sercom: Sealed + Deref<Target = sercom0::RegisterBlock> {
     /// SERCOM number
     const NUM: usize;
     /// RX Trigger source for DMA transactions
+    #[cfg(feature = "dma")]
     const DMA_RX_TRIGGER: TriggerSource;
     /// TX trigger source for DMA transactions
+    #[cfg(feature = "dma")]
     const DMA_TX_TRIGGER: TriggerSource;
     /// Enable the corresponding APB clock
     fn enable_apb_clock(&mut self, ctrl: &APB_CLK_CTRL);
@@ -62,7 +64,9 @@ macro_rules! sercom {
                 impl Sealed for Sercom#N {}
                 impl Sercom for Sercom#N {
                     const NUM: usize = N;
+                    #[cfg(feature = "dma")]
                     const DMA_RX_TRIGGER: TriggerSource = TriggerSource::[<SERCOM#N _RX>];
+                    #[cfg(feature = "dma")]
                     const DMA_TX_TRIGGER: TriggerSource = TriggerSource::[<SERCOM#N _TX>];
                     #[inline]
                     fn enable_apb_clock(&mut self, ctrl: &APB_CLK_CTRL) {


### PR DESCRIPTION
Here's a potential implementation of the `recycle()` method we chatted about yesterday.  I wonder if it's worth adding a Result type to the DMAC module?