### PR TITLE
CI work continues

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -65,7 +65,14 @@ jobs:
 
               VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
               TAG_NAME="${PAC_NAME}-${VERSION}"
-              (git tag -a $TAG_NAME -m "${PAC_NAME} release ${VERSION}" && git push origin tag "$TAG_NAME")|| (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+              
+              if ! git tag -a $TAG_NAME -m "${PAC_NAME} release ${VERSION}" && git push origin tag "$TAG_NAME"; then
+                if git tag --points-at "$(git rev-parse HEAD)" | grep "$TAG_NAME" > /dev/null; then
+                  echo '(and points at this commit). Continuing.'
+                else
+                  false
+                fi
+              fi
 
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
@@ -99,7 +106,14 @@ jobs:
           
           # Create+push a git tag. If that fails, check if an identical tag already exists at the
           # same commit. Bail otherwise.
-          (git tag -a $TAG_NAME -m "atsamd-hal release ${VERSION}" && git push origin tag "$TAG_NAME") || (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+          if ! git tag -a $TAG_NAME -m "atsamd-hal release ${VERSION}" && git push origin tag "$TAG_NAME"; then
+            if git tag --points-at "$(git rev-parse HEAD)" | grep "$TAG_NAME" > /dev/null; then
+              echo '(and points at this commit). Continuing.'
+            else
+              false
+            fi
+          fi
+
 
           cargo publish
 
@@ -140,7 +154,14 @@ jobs:
 
               VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
               TAG_NAME="${bsp}-${VERSION}"
-              (git tag -a $TAG_NAME -m "${bsp} release ${VERSION}" && git push origin tag "$TAG_NAME") || (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+
+              if ! git tag -a $TAG_NAME -m "${bsp} release ${VERSION}" && git push origin tag "$TAG_NAME"; then
+                if git tag --points-at "$(git rev-parse HEAD)" | grep "$TAG_NAME" > /dev/null; then
+                  echo '(and points at this commit). Continuing.'
+                else
+                  false
+                fi
+              fi
 
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -58,7 +58,6 @@ jobs:
           do
             (
               cd "${d}"
-              set +e
 
               PAC_NAME="${d#pac/}"
               PAC_NAME="${PAC_NAME%/}"
@@ -74,6 +73,7 @@ jobs:
                 fi
               fi
 
+              set +e
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
               if [[ "$PUBLISH_ERR" == *" is already uploaded"* ]]; then
@@ -150,7 +150,6 @@ jobs:
           do
             (
               cd "boards/${bsp}"
-              set +e
 
               VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
               TAG_NAME="${bsp}-${VERSION}"
@@ -163,6 +162,7 @@ jobs:
                 fi
               fi
 
+              set +e
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
               if [[ "$PUBLISH_ERR" == *" is already uploaded"* ]]; then


### PR DESCRIPTION
Changes as discussed in chat - I think at some stage we should consider refactoring the CI scripts so that there's only one copy of the tag-and-publish code, but in the mean time this is a step in the right direction.